### PR TITLE
Proxy class cashing bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,8 @@
                                         <exclude>com.remondis.resample.supplier.Suppliers</exclude>
                                         <exclude>com.remondis.resample.AutoSamplingException</exclude>
                                         <exclude>com.remondis.resample.Samples.Default</exclude>
+                                        <exclude>com.remondis.resample.Samples.InvocationSensor</exclude>
+                                        <exclude>com.remondis.resample.Samples.InterceptionHandler</exclude>
                                     </excludes>
                                     <element>CLASS</element>
                                     <limits>

--- a/pom.xml
+++ b/pom.xml
@@ -542,7 +542,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.12.8</version>
+            <version>1.14.18</version>
         </dependency>
 
 		<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,42 @@
                                         </limit>
                                     </limits>
                                 </rule>
-
+                                <rule>
+                                    <includes>
+                                        <include>com.remondis.resample.InvocationSensor</include>
+                                    </includes>
+                                    <element>CLASS</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.97</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <includes>
+                                        <include>com.remondis.resample.InterceptionHandler</include>
+                                    </includes>
+                                    <element>CLASS</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.66</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.96</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
                             </rules>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.remondis</groupId>
     <artifactId>resample</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <packaging>jar</packaging>
     <name>ReSample</name>
     <url>https://github.com/remondis-it/resample</url>
@@ -257,7 +257,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -291,8 +291,8 @@
                                         <exclude>com.remondis.resample.supplier.Suppliers</exclude>
                                         <exclude>com.remondis.resample.AutoSamplingException</exclude>
                                         <exclude>com.remondis.resample.Samples.Default</exclude>
-                                        <exclude>com.remondis.resample.Samples.InvocationSensor</exclude>
-                                        <exclude>com.remondis.resample.Samples.InterceptionHandler</exclude>
+                                        <exclude>com.remondis.resample.InvocationSensor</exclude>
+                                        <exclude>com.remondis.resample.InterceptionHandler</exclude>
                                     </excludes>
                                     <element>CLASS</element>
                                     <limits>

--- a/src/main/java/com/remondis/resample/InterceptionHandler.java
+++ b/src/main/java/com/remondis/resample/InterceptionHandler.java
@@ -40,6 +40,7 @@ public class InterceptionHandler<T> {
   }
 
   public boolean hasTrackedProperties() {
-    return nonNull(threadLocalPropertyNames.get()) && !threadLocalPropertyNames.get().isEmpty();
+    return nonNull(threadLocalPropertyNames.get()) && !threadLocalPropertyNames.get()
+        .isEmpty();
   }
 }

--- a/src/main/java/com/remondis/resample/InterceptionHandler.java
+++ b/src/main/java/com/remondis/resample/InterceptionHandler.java
@@ -1,0 +1,45 @@
+package com.remondis.resample;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+public class InterceptionHandler<T> {
+
+  private T proxyObject;
+  private final ThreadLocal<List<String>> threadLocalPropertyNames = ThreadLocal.withInitial(LinkedList::new);
+
+  public void setProxyObject(T proxyObject) {
+    this.proxyObject = proxyObject;
+  }
+
+  public T getProxyObject() {
+    return proxyObject;
+  }
+
+  public List<String> getTrackedPropertyNames() {
+    List<String> list = threadLocalPropertyNames.get();
+    // Reset thread local after access.
+    reset();
+    return isNull(list) ? Collections.emptyList() : unmodifiableList(list);
+  }
+
+  public List<String> getThreadLocalPropertyNames() {
+    return threadLocalPropertyNames.get();
+  }
+
+  /**
+   * Resets the thread local list of property names.
+   */
+  void reset() {
+    threadLocalPropertyNames.remove();
+  }
+
+  public boolean hasTrackedProperties() {
+    return nonNull(threadLocalPropertyNames.get()) && !threadLocalPropertyNames.get().isEmpty();
+  }
+}

--- a/src/main/java/com/remondis/resample/InvocationSensor.java
+++ b/src/main/java/com/remondis/resample/InvocationSensor.java
@@ -41,17 +41,17 @@ class InvocationSensor<T> {
       this.interceptionHandler = (InterceptionHandler<T>) interceptionHandlerCache.get(superType);
     } else {
       Class<? extends T> proxyClass = new ByteBuddy().subclass(superType)
-              .method(isGetter())
-              .intercept(of((proxy, method, args) -> markPropertyAsCalled(method)))
-              .method(isDeclaredBy(Object.class))
-              .intercept(of((proxy, method, args) -> invokeMethodProxySafe(method, this, args)))
-              .method(not(isGetter()).and(not(isDeclaredBy(Object.class))))
-              .intercept(of((proxy, method, args) -> {
-                throw ReflectionException.notAGetter(method);
-              }))
-              .make()
-              .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
-              .getLoaded();
+          .method(isGetter())
+          .intercept(of((proxy, method, args) -> markPropertyAsCalled(method)))
+          .method(isDeclaredBy(Object.class))
+          .intercept(of((proxy, method, args) -> invokeMethodProxySafe(method, this, args)))
+          .method(not(isGetter()).and(not(isDeclaredBy(Object.class))))
+          .intercept(of((proxy, method, args) -> {
+            throw ReflectionException.notAGetter(method);
+          }))
+          .make()
+          .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
+          .getLoaded();
       this.interceptionHandler = new InterceptionHandler<>();
       this.interceptionHandler.setProxyObject(superType.cast(ReflectionUtil.newInstance(proxyClass)));
       interceptionHandlerCache.put(superType, this.interceptionHandler);
@@ -60,7 +60,8 @@ class InvocationSensor<T> {
 
   private Object markPropertyAsCalled(Method method) {
     String propertyName = toPropertyName(method);
-    interceptionHandler.getThreadLocalPropertyNames().add(propertyName);
+    interceptionHandler.getThreadLocalPropertyNames()
+        .add(propertyName);
     return nullOrDefaultValue(method.getReturnType());
   }
 
@@ -79,7 +80,7 @@ class InvocationSensor<T> {
    * @return Returns the tracked property names.
    */
   List<String> getTrackedPropertyNames() {
-      return interceptionHandler.getTrackedPropertyNames();
+    return interceptionHandler.getTrackedPropertyNames();
   }
 
   /**
@@ -89,14 +90,12 @@ class InvocationSensor<T> {
    *         <code>false</code> is returned.
    */
   boolean hasTrackedProperties() {
-      return interceptionHandler.hasTrackedProperties();
+    return interceptionHandler.hasTrackedProperties();
   }
-
 
   void reset() {
     interceptionHandler.reset();
   }
-
 
   private static Object nullOrDefaultValue(Class<?> returnType) {
     if (returnType.isPrimitive()) {

--- a/src/main/java/com/remondis/resample/InvocationSensor.java
+++ b/src/main/java/com/remondis/resample/InvocationSensor.java
@@ -4,13 +4,15 @@ import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 
 import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.remondis.resample.ReflectionUtil.defaultValue;
 import static com.remondis.resample.ReflectionUtil.invokeMethodProxySafe;
 import static com.remondis.resample.ReflectionUtil.toPropertyName;
+import static java.lang.ClassLoader.getSystemClassLoader;
+import static java.util.Objects.isNull;
 import static net.bytebuddy.implementation.InvocationHandlerAdapter.of;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isGetter;
@@ -24,30 +26,41 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
  */
 class InvocationSensor<T> {
 
-  private T proxyObject;
+  static Map<Class<?>, InterceptionHandler<?>> interceptionHandlerCache = new ConcurrentHashMap<>();
 
-  private List<String> propertyNames = new LinkedList<>();
+  private InterceptionHandler<T> interceptionHandler;
 
   InvocationSensor(Class<T> superType) {
-    Class<? extends T> proxyClass = new ByteBuddy().subclass(superType)
-        .method(isGetter())
-        .intercept(of((proxy, method, args) -> markPropertyAsCalled(method)))
-        .method(isDeclaredBy(Object.class))
-        .intercept(of((proxy, method, args) -> invokeMethodProxySafe(method, this, args)))
-        .method(not(isGetter()).and(not(isDeclaredBy(Object.class))))
-        .intercept(of((proxy, method, args) -> {
-          throw ReflectionException.notAGetter(method);
-        }))
-        .make()
-        .load(getClass().getClassLoader(), ClassLoadingStrategy.Default.INJECTION)
-        .getLoaded();
-
-    proxyObject = superType.cast(ReflectionUtil.newInstance(proxyClass));
+    ClassLoader classLoader;
+    if (isNull(superType) || isNull(superType.getClassLoader())) {
+      classLoader = getSystemClassLoader();
+    } else {
+      classLoader = superType.getClassLoader();
+    }
+    if (interceptionHandlerCache.containsKey(superType)) {
+      this.interceptionHandler = (InterceptionHandler<T>) interceptionHandlerCache.get(superType);
+    } else {
+      Class<? extends T> proxyClass = new ByteBuddy().subclass(superType)
+              .method(isGetter())
+              .intercept(of((proxy, method, args) -> markPropertyAsCalled(method)))
+              .method(isDeclaredBy(Object.class))
+              .intercept(of((proxy, method, args) -> invokeMethodProxySafe(method, this, args)))
+              .method(not(isGetter()).and(not(isDeclaredBy(Object.class))))
+              .intercept(of((proxy, method, args) -> {
+                throw ReflectionException.notAGetter(method);
+              }))
+              .make()
+              .load(classLoader, ClassLoadingStrategy.Default.INJECTION)
+              .getLoaded();
+      this.interceptionHandler = new InterceptionHandler<>();
+      this.interceptionHandler.setProxyObject(superType.cast(ReflectionUtil.newInstance(proxyClass)));
+      interceptionHandlerCache.put(superType, this.interceptionHandler);
+    }
   }
 
   private Object markPropertyAsCalled(Method method) {
     String propertyName = toPropertyName(method);
-    propertyNames.add(propertyName);
+    interceptionHandler.getThreadLocalPropertyNames().add(propertyName);
     return nullOrDefaultValue(method.getReturnType());
   }
 
@@ -57,7 +70,7 @@ class InvocationSensor<T> {
    * @return The proxy.
    */
   T getSensor() {
-    return proxyObject;
+    return interceptionHandler.getProxyObject();
   }
 
   /**
@@ -66,25 +79,24 @@ class InvocationSensor<T> {
    * @return Returns the tracked property names.
    */
   List<String> getTrackedPropertyNames() {
-    return Collections.unmodifiableList(propertyNames);
+      return interceptionHandler.getTrackedPropertyNames();
   }
 
   /**
    * Checks if there were any properties accessed by get calls.
    *
-   * @return Returns <code>true</code> if there were at least one interaction with
-   *         a property. Otherwise <code>false</code> is returned.
+   * @return Returns <code>true</code> if there were at least one interaction with a property. Otherwise
+   *         <code>false</code> is returned.
    */
   boolean hasTrackedProperties() {
-    return !propertyNames.isEmpty();
+      return interceptionHandler.hasTrackedProperties();
   }
 
-  /**
-   * Resets all tracked information.
-   */
+
   void reset() {
-    propertyNames.clear();
+    interceptionHandler.reset();
   }
+
 
   private static Object nullOrDefaultValue(Class<?> returnType) {
     if (returnType.isPrimitive()) {

--- a/src/test/java/com/remondis/resample/Dummy.java
+++ b/src/test/java/com/remondis/resample/Dummy.java
@@ -1,12 +1,17 @@
 package com.remondis.resample;
 
+import java.util.Objects;
+
 public class Dummy {
 
   private String field;
 
-  public Dummy(String field) {
+  private String anotherField;
+
+  public Dummy(String field, String anotherField) {
     super();
     this.field = field;
+    this.anotherField = anotherField;
   }
 
   public Dummy() {
@@ -21,12 +26,17 @@ public class Dummy {
     this.field = field;
   }
 
+  public String getAnotherField() {
+    return anotherField;
+  }
+
+  public void setAnotherField(String anotherField) {
+    this.anotherField = anotherField;
+  }
+
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((field == null) ? 0 : field.hashCode());
-    return result;
+    return Objects.hash(field, anotherField);
   }
 
   @Override
@@ -38,12 +48,12 @@ public class Dummy {
     if (getClass() != obj.getClass())
       return false;
     Dummy other = (Dummy) obj;
-    if (field == null) {
-      if (other.field != null)
-        return false;
-    } else if (!field.equals(other.field))
-      return false;
-    return true;
+    return Objects.equals(field, other.field) && Objects.equals(anotherField, other.anotherField);
+  }
+
+  @Override
+  public String toString() {
+    return "Dummy [field=" + field + ", anotherField=" + anotherField + "]";
   }
 
 }

--- a/src/test/java/com/remondis/resample/InvocationSensorTest.java
+++ b/src/test/java/com/remondis/resample/InvocationSensorTest.java
@@ -2,11 +2,14 @@ package com.remondis.resample;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.Semaphore;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,6 +23,7 @@ public class InvocationSensorTest {
   public void setup() {
     this.sensor = new InvocationSensor<>(TestBean.class);
     this.sensorObject = this.sensor.getSensor();
+    InvocationSensor.interceptionHandlerCache.clear();
   }
 
   @Test
@@ -73,4 +77,66 @@ public class InvocationSensorTest {
     assertFalse(sensor.hasTrackedProperties());
   }
 
+  @Test
+  public void shouldCacheThreadSafe() {
+
+    Semaphore s1 = new Semaphore(1);
+    s1.acquireUninterruptibly();
+
+    Semaphore s2 = new Semaphore(1);
+    s2.acquireUninterruptibly();
+
+    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(Dummy.class);
+
+    Thread t1 = new Thread(new Runnable() {
+
+      @Override
+      public void run() {
+        InvocationSensor<Dummy> invocationSensor = new InvocationSensor<>(Dummy.class);
+        Dummy sensor = invocationSensor.getSensor();
+        sensor.getField();
+        s2.release();
+        s1.acquireUninterruptibly();
+      }
+    });
+    t1.start();
+
+    // Hier warte bis t1 mindestens getString() aufgerufen hast
+    s2.acquireUninterruptibly();
+    InvocationSensor<Dummy> invocationSensor = new InvocationSensor<>(Dummy.class);
+    List<String> trackedPropertyNames = invocationSensor.getTrackedPropertyNames();
+    assertTrue(trackedPropertyNames.isEmpty());
+    s1.release();
+  }
+
+  @Test
+  public void shouldCache() {
+    assertTrue(InvocationSensor.interceptionHandlerCache.isEmpty());
+    InvocationSensor<Dummy> invocationSensor = new InvocationSensor<>(Dummy.class);
+    assertFalse(InvocationSensor.interceptionHandlerCache.isEmpty());
+    assertTrue(InvocationSensor.interceptionHandlerCache.containsKey(Dummy.class));
+    assertNotNull(InvocationSensor.interceptionHandlerCache.get(Dummy.class));
+
+    InterceptionHandler<?> interceptionHandler = InvocationSensor.interceptionHandlerCache.get(Dummy.class);
+
+    Dummy sensor = invocationSensor.getSensor();
+    sensor.getField();
+
+    List<String> trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(1, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("field"));
+
+    sensor.getAnotherField();
+    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(1, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("anotherField"));
+
+    sensor.getField();
+    sensor.getAnotherField();
+    trackedPropertyNames = interceptionHandler.getTrackedPropertyNames();
+    assertEquals(2, trackedPropertyNames.size());
+    assertTrue(trackedPropertyNames.contains("field"));
+    assertTrue(trackedPropertyNames.contains("anotherField"));
+
+  }
 }

--- a/src/test/java/com/remondis/resample/NoClassLoaderBean.java
+++ b/src/test/java/com/remondis/resample/NoClassLoaderBean.java
@@ -1,0 +1,7 @@
+package com.remondis.resample;
+
+class NoClassLoaderBean {
+  public static ClassLoader getClassLoader() {
+    return null;
+  }
+}

--- a/src/test/java/com/remondis/resample/TestBean.java
+++ b/src/test/java/com/remondis/resample/TestBean.java
@@ -98,6 +98,14 @@ public class TestBean {
     this.primitiveLong = primitiveLong;
   }
 
+  public int getPrimitiveInt() {
+    return 0;
+  }
+
+  public Object getObject() {
+    return null;
+  }
+
   @Override
   public String toString() {
     return "TestBean [strings=" + strings + ", dummies=" + dummies + ", wrapperBoolean=" + wrapperBoolean


### PR DESCRIPTION
This PR tries to reduce the memory footprint of resample by using a type cache while building a mapper configuration.
The classes byte buddy generates are typically not cached. When using a single-classloader environment the classes cannot be unloaded. Therefore the memory footprint of ReMap should be minimal.
 
This PR is a first step to reduce the number of classes generated when configuring one individual mapping configuration.